### PR TITLE
Makes helium-commander buildable with nix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,23 @@ package system-wide
    $ sudo pip install helium-commander
 
 
+Nix
+---
+
+helium-commander can also be installed using the Nix_ package manager. Clone
+the repository and run:
+
+::
+
+   $ nix-env --install --file default.nix
+
+To upgrade on version releases, run:
+
+::
+
+   $ nix-env --upgrade --file default.nix
+
+
 Usage
 =====
 
@@ -64,4 +81,5 @@ To use the `helium` command, explore the help options:
 
 .. _Helium: https://helium.com
 .. _API: https://docs.helium.com
-.. _PyPi: https:pypi.python.org
+.. _PyPi: https://pypi.python.org
+.. _Nix: https://nixos.org/nix/

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,46 @@
+{nixpkgs ? (import <nixpkgs> {})} :
+
+with nixpkgs;
+with pkgs.python27Packages;
+
+let
+
+  dpath = buildPythonPackage {
+    name = "dpath-1.4.0";
+    buildInputs = with self; [];
+    doCheck = false;
+    propagatedBuildInputs = with self; [];
+    src = fetchurl {
+      url = "https://pypi.python.org/packages/6d/3a/d599d29897bf3c7f3a0ddc78f2d2297ebc05b20b875f272f5d8010b77cbe/dpath-1.4.0.tar.gz";
+      md5 = "9725730d39d09690a87c983bcf02b672";
+    };
+  };
+
+  terminaltables = buildPythonPackage {
+    name = "terminaltables-2.1.0";
+    buildInputs = with self; [];
+    doCheck = false;
+    propagatedBuildInputs = with self; [];
+    src = fetchurl {
+      url = "https://pypi.python.org/packages/10/da/9bbb21c1c2f9be4df2056b00b569689b9ece538ef39bf8db34be25f9e850/terminaltables-2.1.0.tar.gz";
+      md5 = "651dadab3eb3ddf21c28374a9002a30f";
+    };
+  };
+
+  helium-commander = buildPythonPackage rec {
+    name = "helium-commander-${version}";
+    version = "0.5.2";
+
+    src = ./.;
+
+    propagatedBuildInputs = with self;
+      [ requests2 futures click dpath terminaltables ];
+
+    meta = {
+      homepage = "http://github.com/helium/helium-commander/";
+      description = "A command line interface to the Helium API";
+      license = stdenv.lib.licenses.bsdOriginal;
+    };
+  };
+
+in helium-commander


### PR DESCRIPTION
Makes helium-commander buildable with nix:

`nix-build` to build helium-commander

`nix-shell` to build helium-commander and enter a shell with `helium` on the path (similiar to virtualenv)

`nix-env -i -f default.nix` to install helium-commander to your environment

`nix-env -u -f default.nix` to upgrade helium-commander when the version number is greater.