### PR TITLE
Add an optional file-like param to tabulate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,14 +73,14 @@ To use the `helium` command, explore the help options:
     Usage: helium [OPTIONS] COMMAND [ARGS]...
 
     Options:
-      --version                Show the version and exit.
-      --format [csv|json|tty]  The output format (default 'tty')
-      --uuid                   Whether to display long identifiers
-      --host TEXT              The Helium base API URL. Can also be specified
-                               using the HELIUM_API_URL environment variable.
-      --api-key TEXT           your Helium API key. Can also be specified using
-                               the HELIUM_API_KEY environment variable
-      -h, --help               Show this message and exit.
+      --version                     Show the version and exit.
+      --format [csv|json|tabular]   The output format (default 'tabular')
+      --uuid                        Whether to display long identifiers
+      --host TEXT                   The Helium base API URL. Can also be specified
+                                    using the HELIUM_API_URL environment variable.
+      --api-key TEXT                your Helium API key. Can also be specified using
+                                    the HELIUM_API_KEY environment variable
+      -h, --help                    Show this message and exit.
 
     Commands:
       cloud-script   Operations on cloud-scripts.

--- a/helium/commands/writer.py
+++ b/helium/commands/writer.py
@@ -18,7 +18,7 @@ def for_format(format, file, **kwargs):
             "indent": None
         }
         return CSVWriter(file, json=json_opts, **kwargs)
-    elif format == 'tty':
+    elif format == 'tabular':
         json_opts = json_opts or {
             "indent": 0
         }


### PR DESCRIPTION
This can be used by functions that want to take advantage of
tabulate-helpers, but are not using stdout. Helpers can be migrated to
simply pass their `**kwargs` directly to `tabulate`.