### PR TITLE
Fix null mac handling

### DIFF
--- a/helium_commander/resource.py
+++ b/helium_commander/resource.py
@@ -14,11 +14,9 @@ def filter_mac(id_rep):
     id_rep_lower = id_rep.lower()
 
     def func(resource):
-        try:
-            resource_mac = resource.meta.mac
+        resource_mac = getattr(resource.meta, 'mac', None)
+        if resource_mac:
             return resource_mac[-len(id_rep):].lower() == id_rep_lower
-        except AttributeError:
-            pass
         return False
     return func
 


### PR DESCRIPTION
The filtering for mac adresses was not dealing well with the mac address being `null` in json. Tightened it up a bit